### PR TITLE
Add functionality to re-download database if local DB is old

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,5 +94,6 @@ dependencies {
 
     // Handles HTTP request easily
     implementation 'com.android.volley:volley:1.1.1'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.3.50"
 
 }

--- a/app/src/main/java/com/example/cattlelog/DownloadDatabase.kt
+++ b/app/src/main/java/com/example/cattlelog/DownloadDatabase.kt
@@ -1,5 +1,6 @@
 package com.example.cattlelog
 
+import android.app.Activity
 import android.app.DownloadManager
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -10,8 +11,14 @@ import android.os.Bundle
 import android.os.Environment
 import android.util.Log
 import android.widget.Toast
+import com.android.volley.DefaultRetryPolicy
+import com.android.volley.Response
+import com.android.volley.toolbox.JsonObjectRequest
+import com.cfsuman.jetpack.VolleySingleton
+import com.example.cattlelog.model.database.CattlelogDatabase
 import com.example.cattlelog.model.database.CattlelogDatabase.Companion.DATABASE_NAME
 import com.example.cattlelog.utility.Downloader
+import org.json.JSONObject
 import java.io.File
 
 
@@ -67,9 +74,13 @@ class DownloadDatabase : AppCompatActivity() {
             tempDownloadFile.copyTo(targetFile, overwrite = true)
             tempDownloadFile.delete()
             Log.d(LOG_TAG, "File has been copied successfully.")
+            // Activity result must be marked as OK, otherwise it default returns RESULT_CANCELED
+            setResult(Activity.RESULT_OK)
         } catch (e: Exception) {
             Log.d(LOG_TAG, "Error copying file.")
             Log.e(LOG_TAG, "exception", e)
         }
     }
+
+
 }


### PR DESCRIPTION
When you test this branch, hit the Test SQL Query button.  In the logs, it should say `Local database is out of date, get new version. and then automatically download the new database.`  (Your database isn't actually out of date, but there probably isn't a shared preference string stored yet.  I don't think shared prefs are uploaded to GitHub, so this is the functionality I'd expect.)

After the download, it should say `The stored database version has been set to (timestamp) in the log.`  Then, if you hit the Test SQL Query button, the log should say `Local database is up to date.`  Let me know it works when you get a chance.  Remember to sync gradle if necessary.